### PR TITLE
Bring in changes from cockpit repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,14 @@
-FROM fedora:22
+FROM fedora:24
 MAINTAINER "Stef Walter" <stefw@redhat.com>
 
-RUN dnf -y update
+ARG RELEASE=1
+ARG VERSION=119
+ARG COCKPIT_RPM_URL=https://kojipkgs.fedoraproject.org/packages/cockpit
 
-ENV VERSION 119
-ENV RELEASE 1
+ADD . /container
 
-# Get this specific version of cockpit-ws
-RUN dnf -y install sed https://kojipkgs.fedoraproject.org/packages/cockpit/$VERSION/$RELEASE.fc23/x86_64/cockpit-ws-$VERSION-$RELEASE.fc23.x86_64.rpm && dnf clean all
-
-# And the stuff that starts the container
-RUN mkdir -p /container && ln -s /host/proc/1 /container/target-namespace
-ADD atomic-install /container/atomic-install
-ADD atomic-uninstall /container/atomic-uninstall
-ADD atomic-run /container/atomic-run
-RUN chmod -v +x /container/atomic-install
-RUN chmod -v +x /container/atomic-uninstall
-RUN chmod -v +x /container/atomic-run
+# Again see above ... we do our branching in shell script
+RUN /container/install-package.sh
 
 # Make the container think it's the host OS version
 RUN rm -f /etc/os-release /usr/lib/os-release && ln -sv /host/etc/os-release /etc/os-release && ln -sv /host/usr/lib/os-release /usr/lib/os-release

--- a/install-package.sh
+++ b/install-package.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -ex
+
+dnf -y update
+dnf install -y sed
+
+OS=$(rpm -q --qf "%{release}" basesystem | sed -n -e 's/^[0-9]*\.\(\S\+\).*/\1/p')
+
+rpm=$(ls /container/rpms/cockpit-ws*.rpm || true)
+
+if [ -z "$RELEASE" ]; then
+    RELEASE=1
+fi
+
+# If there are rpm files in the current directory we'll install those
+if [ -n "$rpm" ]; then
+    dnf -y install /container/rpms/cockpit-ws*.rpm
+
+# If there is a url set, pull the version from there
+# requires the build arg VERSION to be set
+elif [ -n "$COCKPIT_RPM_URL" ]; then
+    dnf -y install "$COCKPIT_RPM_URL/$VERSION/$RELEASE.$OS/x86_64/cockpit-ws-$VERSION-$RELEASE.$OS.x86_64.rpm"
+
+# Otherwise just do the standard install
+# requires the build arg VERSION to be set
+else
+    dnf -y install cockpit-ws-$VERSION-$RELEASE.$OS
+fi
+
+dnf clean all
+rm -rf /container/rpms || true
+
+# And the stuff that starts the container
+ln -s /host/proc/1 /container/target-namespace
+chmod -v +x /container/atomic-install
+chmod -v +x /container/atomic-uninstall
+chmod -v +x /container/atomic-run


### PR DESCRIPTION
I wanted to change the docker build target to the cockpituous fork like we do for the kubernetes container but apparently docker doesn't let you do that. So this brings in the changes from cockpit/containers/ws into this repo.