### PR TITLE
Bind-mount /etc/ssh

### DIFF
--- a/atomic-install
+++ b/atomic-install
@@ -42,6 +42,9 @@ mkdir -p /host/var/lib/cockpit
 chmod 775 /host/var/lib/cockpit
 chown root:wheel /host/var/lib/cockpit
 
+# For sharing ssh's known hosts with container
+mkdir -p /etc/ssh
+
 # Ensure we have certificates
 /bin/mount --bind /host/etc/cockpit /etc/cockpit
 /usr/sbin/remotectl certificate --ensure

--- a/atomic-run
+++ b/atomic-run
@@ -15,6 +15,7 @@ set +x
 
 /bin/mount --bind /host/usr/share/pixmaps /usr/share/pixmaps
 /bin/mount --bind /host/var /var
+/bin/mount --bind /host/etc/ssh /etc/ssh
 
 # And run cockpit-ws
 exec /usr/bin/nsenter --net=/container/target-namespace/ns/net --uts=/container/target-namespace/ns/uts -- /usr/libexec/cockpit-ws "$@"


### PR DESCRIPTION
machines.js will soon write SSH known host keys to
/etc/ssh/ssh_known_hosts, thus /etc/ssh needs to be bind-mounted into
the ws container in addition to /var.

Sync with corresponding cockpit change:
https://github.com/cockpit-project/cockpit/pull/6074