### PR TITLE
Pull fedora image from registry.fedoraproject.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM registry.fedoraproject.org/fedora:33
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 LABEL VERSION=241
 


### PR DESCRIPTION
Otherwise it pulls from docker.io where we can hit pull rate limit.